### PR TITLE
Add link to reference docs in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -161,6 +161,8 @@ Documentation
 
 https://python-litmos-api.readthedocs.io/
 
+https://docs.contour.so/Flockjay/python-litmos-api/getting-started
+
 Development
 -----------
 


### PR DESCRIPTION
Hi there!

My name is Leo, a CS student at Brown building an automated platform for editable codebase documentation.

I generated documentation for this repository and placed a link in the README. Please feel free to try it out and let me know what you think!